### PR TITLE
Simplify CAN port code

### DIFF
--- a/examples/012-can/f107vc/src/main.c
+++ b/examples/012-can/f107vc/src/main.c
@@ -48,7 +48,7 @@ int main(void) {
     };
     can1.config(1000, CAN_MODE_NORMAL);
     can1.irq.attach(0x666, Can1IrqTest, "Can1IrqTest");
-
+    can1.irq.show();
     // tasks -----------
     stime.scheduler.attach(2000, 1, taskCan1Test, "taskCan1Test");
     stime.scheduler.show();

--- a/examples/012-can/f407zg/src/main.c
+++ b/examples/012-can/f407zg/src/main.c
@@ -1,10 +1,34 @@
 #include "config.h"
 
 // =============================================================================
-static void taskCan1Test(void) {
+static void taskCan1Test1(void) {
     uint8_t data[8];
     for (int i = 0; i < 8; i++) {
         data[i] = (i + 1) * 16 + (i + 1);
+    }
+
+    uint16_t id = 0x666;
+    uint8_t len = 8;
+    static uint32_t loop_count = 0;
+    if (can1.sendData(id, data, len) != HAL_OK) {
+        console.printf("%5d: failed to send a CAN1 message\r\n", loop_count);
+    }
+    else {
+        console.printf("%5d: sent a CAN1 message: (0x%04X, %d)", loop_count, id,
+                       len);
+        for (int i = 0; i < len; i++) {
+            console.printf(" %02X", data[i]);
+        }
+        console.printf("\r\n");
+    }
+    loop_count++;
+}
+
+// =============================================================================
+static void taskCan1Test2(void) {
+    uint8_t data[8];
+    for (int i = 0; i < 8; i++) {
+        data[i] = (i + 1) * 8 + (i + 1);
     }
 
     uint16_t id = 0x555;
@@ -85,9 +109,12 @@ int main(void) {
     can2.config(1000, CAN_MODE_NORMAL);
     can1.irq.attach(0x666, Can1IrqTest, "Can1IrqTest");
     can2.irq.attach(0x0AB, Can2IrqTest, "Can2IrqTest");
+    can1.irq.show();
+    can2.irq.show();
 
     // tasks -----------
-    stime.scheduler.attach(2000, 1, taskCan1Test, "taskCan1Test");
+    stime.scheduler.attach(2000, 1, taskCan1Test1, "taskCan1Test1");
+    stime.scheduler.attach(2000, 500, taskCan1Test2, "taskCan1Test2");
     stime.scheduler.attach(2000, 1000, taskCan2Test, "taskCan2Test");
     stime.scheduler.show();
 

--- a/examples/012-can/f407zg/src/main.c
+++ b/examples/012-can/f407zg/src/main.c
@@ -108,6 +108,7 @@ int main(void) {
     can1.config(1000, CAN_MODE_NORMAL);
     can2.config(1000, CAN_MODE_NORMAL);
     can1.irq.attach(0x666, Can1IrqTest, "Can1IrqTest");
+    can1.irq.attach(0x666, Can2IrqTest, "Can2IrqTest");  // this will fail
     can2.irq.attach(0x0AB, Can2IrqTest, "Can2IrqTest");
     can1.irq.show();
     can2.irq.show();

--- a/one-third-hal/core/can/can.c
+++ b/one-third-hal/core/can/can.c
@@ -139,6 +139,45 @@ void can_irq_show_registration(const char* str, CanIrqNode_t* node,
     }
     CONSOLE_PRINTF_SEG;
 }
+
+// ============================================================================
+bool can_irq_attach(CanIrqNode_t* node, uint8_t num, uint16_t cob_id,
+                    can_irq_hook hook, const char* str) {
+    uint8_t len;
+    uint8_t str_len = strlen(str);
+    if (str_len >= _CAN_IRQ_DESCR_SIZE - 1) {
+        len = _CAN_IRQ_DESCR_SIZE - 1;
+    }
+    else {
+        len = str_len;
+    }
+    // you cannot attach two callback functions to one ID
+    if (num > 0) {
+        for (uint8_t i = 0; i < num; i++) {
+            if (node[0].this_.cob_id == cob_id) {
+                return false;
+            }
+        }
+    }
+    if (num == 0) {
+        node[0].this_.cob_id = cob_id;
+        bzero(node[0].this_.descr, _CAN_IRQ_DESCR_SIZE);
+        strncpy(node[0].this_.descr, str, len);
+        node[0].this_.descr[len] = '\0';
+        node[0].this_.hook = hook;
+        node[0].next_ = NULL;
+    }
+    else {
+        node[num].this_.cob_id = cob_id;
+        bzero(node[num].this_.descr, _CAN_IRQ_DESCR_SIZE);
+        strncpy(node[num].this_.descr, str, len);
+        node[num].this_.descr[len] = '\0';
+        node[num].this_.hook = hook;
+        node[num - 1].next_ = &node[num];
+    }
+    return true;
+}
+
 // ============================================================================
 // arguments
 // bit_rate (Kbps):

--- a/one-third-hal/core/can/can.c
+++ b/one-third-hal/core/can/can.c
@@ -71,7 +71,7 @@ static void CAN_Bit_Rate_Process(uint16_t b_rate_k, CAN_InitTypeDef* can_init) {
         }
     }
     if (iter == CAN_BIT_RATE_NUM) {
-        console.error("CAN_Bit_Rate_Process(): wrong bit rate!\r\n");
+        can_error(0, "CAN_Bit_Rate_Process(): wrong bit rate!\r\n");
     }
 }
 
@@ -106,7 +106,7 @@ HAL_StatusTypeDef can_send_packet(CAN_HandleTypeDef* handle, uint16_t can_id,
     // is this the right way to check mailbox?
     if ((mailbox != CAN_TX_MAILBOX0) && (mailbox != CAN_TX_MAILBOX1)
         && (mailbox != CAN_TX_MAILBOX2)) {
-        console.printf("%s(): no mail box.", __func__);
+        can_printk(0, "%s(): no mail box.", __func__);
         return HAL_ERROR;
     }
     return state;
@@ -114,14 +114,31 @@ HAL_StatusTypeDef can_send_packet(CAN_HandleTypeDef* handle, uint16_t can_id,
 
 // ============================================================================
 void can_rx_print(const char* canx, CAN_RxHeaderTypeDef msg, uint8_t* data) {
-    console.printf(YLW "%s IRQ " NOC "(id: 0x%04X, DLC: %d):", canx, msg.StdId,
-                   msg.DLC);
+    can_printk(0, YLW "%s IRQ " NOC "(id: 0x%04X, DLC: %d):", canx, msg.StdId,
+               msg.DLC);
     for (int i = 0; i < msg.DLC; i++) {
-        console.printf(" %02X", data[i]);
+        can_printk(0, " %02X", data[i]);
     }
-    console.printf("\r\n");
+    can_printk(0, "\r\n");
 }
 
+// ============================================================================
+void can_irq_show_registration(const char* str, CanIrqNode_t* node,
+                               uint8_t num) {
+    CONSOLE_PRINTF_SEG;
+    can_printk(0, "%s IRQ registration | %2d callback", str, num);
+    if (num <= 1) {
+        can_printk(0, "\r\n");
+    }
+    else {
+        can_printk(0, "s\r\n");
+    }
+    for (uint8_t i = 0; i < num; i++) {
+        can_printk(0, "COB ID = 0x%03X : %s\r\n", node[i].this_.cob_id,
+                   node[i].this_.descr);
+    }
+    CONSOLE_PRINTF_SEG;
+}
 // ============================================================================
 // arguments
 // bit_rate (Kbps):
@@ -141,7 +158,7 @@ void can_settings(CAN_HandleTypeDef* hcan, uint16_t b_rate_k, uint32_t mode) {
     hcan->Init.ReceiveFifoLocked = DISABLE;
     hcan->Init.TransmitFifoPriority = ENABLE;
     if (HAL_CAN_Init(hcan) != HAL_OK) {
-        console.error("failed to setup the CAN interface.\r\n");
+        can_error(0, "failed to setup the CAN interface.\r\n");
     }
 
     // filter: to accept all, may have some bug because mixed all CANs
@@ -157,7 +174,7 @@ void can_settings(CAN_HandleTypeDef* hcan, uint16_t b_rate_k, uint32_t mode) {
     can_filter.FilterActivation = ENABLE;
     can_filter.SlaveStartFilterBank = 0;
     if (HAL_CAN_ConfigFilter(hcan, &can_filter) != HAL_OK) {
-        console.error("failed to setup CAN filter.\r\n");
+        can_error(0, "failed to setup CAN filter.\r\n");
     }
 }
 

--- a/one-third-hal/core/can/can.h
+++ b/one-third-hal/core/can/can.h
@@ -9,6 +9,7 @@ extern "C" {
 #include "config.h"
 
 #include "config-can.h"
+#include "uart-console.h"
 
 // clang-format off
 #if defined(CAN1_EXISTS)
@@ -35,6 +36,16 @@ extern "C" {
 
 // ----------------------------------------------------------------------------
 #if defined(CAN_IS_USED)
+
+#ifdef CONSOLE_IS_USED
+#define can_printf(...) (console.printf(__VA_ARGS__))
+#define can_printk(...) (console.printk(__VA_ARGS__))
+#define can_error(...) (console.error(__VA_ARGS__))
+#else
+#define can_printf(...) ({ ; })
+#define can_printk(...) ({ ; })
+#define can_error(...) ({ ; })
+#endif
 
 // FreeRTOS related configuration
 // clang-format off
@@ -89,7 +100,8 @@ bool can_check_bit_rate(uint16_t b_rate_k);
 HAL_StatusTypeDef can_send_packet(CAN_HandleTypeDef* handle, uint16_t can_id,
                                   uint32_t type, uint8_t* data, uint8_t len);
 void can_rx_print(const char* canx, CAN_RxHeaderTypeDef msg, uint8_t* data);
-
+void can_irq_show_registration(const char* str, CanIrqNode_t* node,
+                               uint8_t num);
 typedef struct {
     void (*attach)(uint16_t, can_irq_hook, const char*);
     void (*show)(void);

--- a/one-third-hal/core/can/can.h
+++ b/one-third-hal/core/can/can.h
@@ -102,6 +102,9 @@ HAL_StatusTypeDef can_send_packet(CAN_HandleTypeDef* handle, uint16_t can_id,
 void can_rx_print(const char* canx, CAN_RxHeaderTypeDef msg, uint8_t* data);
 void can_irq_show_registration(const char* str, CanIrqNode_t* node,
                                uint8_t num);
+bool can_irq_attach(CanIrqNode_t* node, uint8_t num, uint16_t cob_id,
+                    can_irq_hook hook, const char* str);
+
 typedef struct {
     void (*attach)(uint16_t, can_irq_hook, const char*);
     void (*show)(void);

--- a/one-third-hal/core/can/can.h
+++ b/one-third-hal/core/can/can.h
@@ -95,7 +95,6 @@ typedef struct CanIrqNode_s {
 
 // ----------------------------------------------------------------------------
 // functions to be called inside the CAN module
-void can_settings(CAN_HandleTypeDef* hcan, uint16_t b_rate_k, uint32_t mode);
 bool can_check_bit_rate(uint16_t b_rate_k);
 HAL_StatusTypeDef can_send_packet(CAN_HandleTypeDef* handle, uint16_t can_id,
                                   uint32_t type, uint8_t* data, uint8_t len);
@@ -104,6 +103,7 @@ void can_irq_show_registration(const char* str, CanIrqNode_t* node,
                                uint8_t num);
 bool can_irq_attach(CanIrqNode_t* node, uint8_t num, uint16_t cob_id,
                     can_irq_hook hook, const char* str);
+void can_settings(CAN_HandleTypeDef* hcan, uint16_t b_rate_k, uint32_t mode);
 
 typedef struct {
     void (*attach)(uint16_t, can_irq_hook, const char*);

--- a/one-third-hal/core/can/can1.c
+++ b/one-third-hal/core/can/can1.c
@@ -10,33 +10,11 @@
 static CanIrqNode_t can1_node[_CAN_IRQ_MAX_NUM] = { 0 };
 static uint8_t can1_node_num = 0;
 
+// ============================================================================
 static void IrqAttachCan1(uint16_t cob_id, can_irq_hook hook, const char* str) {
-    uint8_t len;
-    uint8_t str_len = strlen(str);
-    if (str_len >= _CAN_IRQ_DESCR_SIZE - 1) {
-        len = _CAN_IRQ_DESCR_SIZE - 1;
+    if (can_irq_attach(can1_node, can1_node_num, cob_id, hook, str)) {
+        can1_node_num++;
     }
-    else {
-        len = str_len;
-    }
-
-    if (can1_node_num == 0) {
-        can1_node[0].this_.cob_id = cob_id;
-        bzero(can1_node[0].this_.descr, _CAN_IRQ_DESCR_SIZE);
-        strncpy(can1_node[0].this_.descr, str, len);
-        can1_node[0].this_.descr[len] = '\0';
-        can1_node[0].this_.hook = hook;
-        can1_node[0].next_ = NULL;
-    }
-    else {
-        can1_node[can1_node_num].this_.cob_id = cob_id;
-        bzero(can1_node[can1_node_num].this_.descr, _CAN_IRQ_DESCR_SIZE);
-        strncpy(can1_node[can1_node_num].this_.descr, str, len);
-        can1_node[can1_node_num].this_.descr[len] = '\0';
-        can1_node[can1_node_num].this_.hook = hook;
-        can1_node[can1_node_num - 1].next_ = &can1_node[can1_node_num];
-    }
-    can1_node_num++;
 }
 
 // ============================================================================

--- a/one-third-hal/core/can/can1.c
+++ b/one-third-hal/core/can/can1.c
@@ -1,4 +1,5 @@
 #include "can.h"
+#include <stdio.h>
 #include <string.h>
 
 // ============================================================================
@@ -40,11 +41,7 @@ static void IrqAttachCan1(uint16_t cob_id, can_irq_hook hook, const char* str) {
 
 // ============================================================================
 static void IrqShowCan1(void) {
-    console.printf("CAN1 registered IRQ functions are:\r\n");
-    for (uint8_t i = 0; i < can1_node_num; i++) {
-        console.printf("COB ID = 0x%03X : %s\r\n", can1_node[i].this_.cob_id,
-                       can1_node[i].this_.descr);
-    }
+    can_irq_show_registration("CAN1", can1_node, can1_node_num);
 }
 
 // ============================================================================
@@ -118,7 +115,7 @@ static void InitCan1(uint16_t b_rate_k, uint32_t mode) {
 
     // start CAN
     if (HAL_CAN_Start(&(can1.hcan)) != HAL_OK) {
-        console.error("failed to start CAN1\r\n");
+        can_error(0, "failed to start CAN1\r\n");
     };
 }
 

--- a/one-third-hal/core/can/can2.c
+++ b/one-third-hal/core/can/can2.c
@@ -40,11 +40,7 @@ static void IrqAttachCan2(uint16_t cob_id, can_irq_hook hook, const char* str) {
 
 // ============================================================================
 static void IrqShowCan2(void) {
-    console.printf("CAN2 registered IRQ functions are:\r\n");
-    for (uint8_t i = 0; i < can2_node_num; i++) {
-        console.printf("COB ID = 0x%03X : %s\r\n", can2_node[i].this_.cob_id,
-                       can2_node[i].this_.descr);
-    }
+    can_irq_show_registration("CAN2", can2_node, can2_node_num);
 }
 
 // ============================================================================
@@ -88,7 +84,7 @@ static void InitCan2(uint16_t b_rate_k, uint32_t mode) {
 
     // start CAN
     if (HAL_CAN_Start(&(can2.hcan)) != HAL_OK) {
-        console.error("failed to start CAN2\r\n");
+        can_error(0, "failed to start CAN2\r\n");
     };
 }
 

--- a/one-third-hal/core/can/can2.c
+++ b/one-third-hal/core/can/can2.c
@@ -10,32 +10,9 @@ static CanIrqNode_t can2_node[_CAN_IRQ_MAX_NUM] = { 0 };
 static uint8_t can2_node_num = 0;
 
 static void IrqAttachCan2(uint16_t cob_id, can_irq_hook hook, const char* str) {
-    uint8_t len;
-    uint8_t str_len = strlen(str);
-    if (str_len >= _CAN_IRQ_DESCR_SIZE - 1) {
-        len = _CAN_IRQ_DESCR_SIZE - 1;
+    if (can_irq_attach(can2_node, can2_node_num, cob_id, hook, str)) {
+        can2_node_num++;
     }
-    else {
-        len = str_len;
-    }
-
-    if (can2_node_num == 0) {
-        can2_node[0].this_.cob_id = cob_id;
-        bzero(can2_node[0].this_.descr, _CAN_IRQ_DESCR_SIZE);
-        strncpy(can2_node[0].this_.descr, str, len);
-        can2_node[0].this_.descr[len] = '\0';
-        can2_node[0].this_.hook = hook;
-        can2_node[0].next_ = NULL;
-    }
-    else {
-        can2_node[can2_node_num].this_.cob_id = cob_id;
-        bzero(can2_node[can2_node_num].this_.descr, _CAN_IRQ_DESCR_SIZE);
-        strncpy(can2_node[can2_node_num].this_.descr, str, len);
-        can2_node[can2_node_num].this_.descr[len] = '\0';
-        can2_node[can2_node_num].this_.hook = hook;
-        can2_node[can2_node_num - 1].next_ = &can2_node[can2_node_num];
-    }
-    can2_node_num++;
 }
 
 // ============================================================================

--- a/one-third-hal/core/uart-console.h
+++ b/one-third-hal/core/uart-console.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 // ============================================================================
 
-// if use this library, we must we this module
+// if use this library, we must use this module
 #include "config.h"
 
 #include <stdbool.h>


### PR DESCRIPTION
* move some functions into can.c so they can be called in can1.c and can2.c
* define can_printf, can_printk and can_error to eliminate compile error when console is not used