### PR TITLE
add config-spi.c file and fix a bug in a Makefile

### DIFF
--- a/examples/012-can/f107vc/Makefile
+++ b/examples/012-can/f107vc/Makefile
@@ -12,12 +12,6 @@ PRJ_NAME  = $(STM32Fx)-binary
 
 PRJ_INCH =  \
     $(LIB_PATH)/core \
-    $(LIB_PATH)/core/config \
-    $(LIB_PATH)/core/iic \
-    $(LIB_PATH)/core/math \
-    $(LIB_PATH)/core/spi \
-    $(LIB_PATH)/core/uart \
-    $(LIB_PATH)/device \
     ./inc
 
 # ------------------------------------------

--- a/one-third-hal/core/config/config-spi.c
+++ b/one-third-hal/core/config/config-spi.c
@@ -1,0 +1,43 @@
+#include "config.h"
+
+#include "config-spi.h"
+
+static uint8_t spi_used = 0;
+
+static uint8_t get_pos(SPI_TypeDef* SPIx) {
+    uint8_t pos = 0;
+    // clang-format off
+    switch ((intptr_t)SPIx) {
+    case (intptr_t)SPI1: pos = 0; break;
+    case (intptr_t)SPI2: pos = 1; break;
+#if defined(SPI3_EXISTS)
+    case (intptr_t)SPI3: pos = 2; break;
+#endif
+#if defined(SPI4_EXISTS)
+    case  (intptr_t)SPI4: pos = 3; break;
+#endif
+#if defined(SPI5_EXISTS)
+    case  (intptr_t)SPI5: pos = 4; break;
+#endif
+#if defined(SPI6_EXISTS)
+    case (intptr_t)SPI6: pos = 5; break;
+#endif
+
+    default: pos = 0; break;}
+    // clang-format on
+    return pos;
+}
+
+static void ConfigSpiSet(SPI_TypeDef* SPIx, bool value) {
+    uint8_t pos = get_pos(SPIx);
+    value ? (spi_used |= 1 << pos) : (spi_used &= ~(1 << pos));
+}
+
+static bool ConfigUSpiCheck(SPI_TypeDef* SPIx) {
+    return _CHECK_BIT(spi_used, get_pos(SPIx));
+}
+
+ConfigSpi_t config_spi = {
+    .set = ConfigSpiSet,
+    .check = ConfigUSpiCheck,
+};


### PR DESCRIPTION
Previous PR does not include the file `config-spi.c` file, this PR is to fix it.