### PR TITLE
fix a git fatal message warning

### DIFF
--- a/build-in-container
+++ b/build-in-container
@@ -23,6 +23,7 @@ fi
 echo -e "${GRN}Build the image \"${image_name}\"${NOC} ..."
 DOCKER_BUILDKIT=1 docker build \
     -t ${image_name} \
+    --build-arg git_safe_dir="$target_path" \
     -f docker/Dockerfile docker
 
 # create a container and run it ------------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,3 +70,11 @@ RUN git clone https://github.com/Neargye/magic_enum && \
     cd magic_enum && \
     git checkout v0.7.3 && \
     cp include/magic_enum.hpp /usr/local/include/
+
+# error seem from ./build-in-container:
+# fatal: unsafe repository ('/one-third-in-container' is owned by someone else)
+# To add an exception for this directory, call:
+
+# solution:
+ARG git_safe_dir
+RUN git config --global --add safe.directory "${git_safe_dir}"

--- a/docker/env
+++ b/docker/env
@@ -6,4 +6,4 @@ YLW='\033[0;33m'
 
 image_name="one-third-hal-stm32-image"
 container_name="one-third-hal-stm32-container"
-target_path="/one-third-in-container"
+target_path="/proj-in-container"


### PR DESCRIPTION
Warnings are seem from ./build-in-container:
```
fatal: unsafe repository ('/one-third-in-container' is owned by someone else)
To add an exception for this directory, call:

 git config --global --add safe.directory "/one-third-in-container"
```